### PR TITLE
Upgrade to work with new ARMI locators.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.pyc
+.project
+.pydevproject
+*.egg-info
+/doc/_build
+/doc/.apidocs
 

--- a/armicontrib/dif3d/outputReaders.py
+++ b/armicontrib/dif3d/outputReaders.py
@@ -41,6 +41,7 @@ from armi.bookkeeping.db import Database3
 from .binaryIO import dif3dFile, pkedit
 from .const import SolutionType
 from .executionOptions import Dif3dOptions
+from .inputWriters import getDIF3DStyleLocatorLabel
 
 # TODO: should be a GlobalFluxResultMapper subclass to get dpa, etc.
 class Dif3dReader:
@@ -179,7 +180,7 @@ class Dif3dReader:
         This could be cached in RAM so it's not computed for power and each flux
         if it turns out to be slow. Pending profiler results.
         """
-        regionName = b.getLocation()
+        regionName = getDIF3DStyleLocatorLabel(b)
         regInd = np.where(self._labels.regionLabels == regionName)[0][0]
         regNum = regInd + 1
         return np.array(np.where(self._geom.coarseMeshRegions == regNum)).T, regInd
@@ -250,7 +251,7 @@ class Dif3dReader:
         stdoutReader = Dif3dStdoutReader(self.opts.outputFile)
         peakFluxes = stdoutReader.readRegionTotals()
         for b in self.r.core.getBlocks():
-            b.p.fluxPeak = peakFluxes[b.getLocation()]
+            b.p.fluxPeak = peakFluxes[getDIF3DStyleLocatorLabel(b)]
 
     def _checkKeffs(self, fluxData):
         """

--- a/armicontrib/dif3d/templates/dif3d.inp
+++ b/armicontrib/dif3d/templates/dif3d.inp
@@ -56,13 +56,13 @@ UNFORM=A.NIP3
 13 {{ "{:6s}".format(region) }} {{ "{:6s}".format(nucID) }} {{"{:.9E}".format(ndens)}}
 {%endfor%}
 {% for block in r.core.getBlocks() %}
-{% set rname = block.name[1:] %}
-14 Z{{ "{:5s} {:6s} 1.0".format(rname, block.name) }}
+{% set rname = getDIF3DStyleBlockName(block)[1:] %}
+14 Z{{ "{:5s} {:6s} 1.0".format(rname, getDIF3DStyleBlockName(block)) }}
 14 Y{{ "{:5s} Z{:5s} 1.0".format(rname, rname) }}
 {%endfor%}
 {% for block in r.core.getBlocks() %}
-{% set rname = block.name[1:] %}
-15 Y{{ "{:5s} {:6s}".format(rname, block.getLocation()) }}
+{% set rname = getDIF3DStyleBlockName(block)[1:] %}
+15 Y{{ "{:5s} {:6s}".format(rname, getDIF3DStyleLocatorLabel(block)) }}
 {%endfor%}
 29 {{ r.core.getAssemblyPitch() }} 0 {{opts.numberMeshPerEdge}}
 {% for loc, ring, position, bottom, top in hexes %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.join(".."))
+sys.path.insert(0, os.path.abspath(os.path.join("..")))
 
 
 import armi


### PR DESCRIPTION
ARMI removed the inherently-limited getLocation functionality so this
implements DIF3D-specific locator and block name shortcuts that will
still have the original limits on number of axial blocks (somewhere
around 50 blocks).

Related to https://github.com/terrapower/armi/issues/233.